### PR TITLE
Fix HSV to HSL conversion

### DIFF
--- a/src/spaces/hsv.js
+++ b/src/spaces/hsv.js
@@ -44,12 +44,12 @@ Color.defineSpace({
 			s /= 100;
 			v /= 100;
 
-			let l = 100 * v * (1 - s/2);
+			let l = v * (1 - s/2);
 
 			return [
 				h, // h is the same
-				(l === 0 || l === 1)? 0 : (v - l) / Math.min(l, 1 - l),
-				l
+				(l === 0 || l === 1)? 0 : ((v - l) / Math.min(l, 1 - l)) * 100,
+				l * 100
 			];
 		}
 	}


### PR DESCRIPTION
Do not scale lightness back to 0 - 100 until conversions are done.

Before fix:

```js
>  new Color("color(hsv 60 50 40)").to('srgb').to('hsv').toString()
'color(hsv 60.001 2.021 30.306)'
```

After fix:

```js
>  new Color("color(hsv 60 50 40)").to('srgb').to('hsv').toString()
'color(hsv 60 50 40)'
```