### PR TITLE
Pass epsilon to spaces that redirect the inGamut check

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -258,7 +258,7 @@ export default class Color {
 		space = Color.space(space);
 
 		if (space.inGamut) {
-			return space.inGamut(coords);
+			return space.inGamut(coords, epsilon);
 		}
 		else {
 			if (!space.coords) {

--- a/src/spaces/hsl.js
+++ b/src/spaces/hsl.js
@@ -9,9 +9,9 @@ Color.defineSpace({
 		saturation: [0, 100],
 		lightness: [0, 100]
 	},
-	inGamut (coords) {
+	inGamut (coords, epsilon) {
 		let rgb = this.to.srgb(coords);
-		return Color.inGamut("srgb", rgb);
+		return Color.inGamut("srgb", rgb, {epsilon: epsilon});
 	},
 	white: Color.whites.D65,
 

--- a/src/spaces/hsv.js
+++ b/src/spaces/hsv.js
@@ -13,9 +13,9 @@ Color.defineSpace({
 		saturation: [0, 100],
 		value: [0, 100]
 	},
-	inGamut (coords) {
+	inGamut (coords, epsilon) {
 		let hsl = this.to.hsl(coords);
-		return Color.spaces.hsl.inGamut(hsl);
+		return Color.spaces.hsl.inGamut(hsl, {epsilon: epsilon});
 	},
 	white: Color.whites.D65,
 

--- a/src/spaces/hwb.js
+++ b/src/spaces/hwb.js
@@ -13,9 +13,9 @@ Color.defineSpace({
 		whiteness: [0, 100],
 		blackness: [0, 100]
 	},
-	inGamut (coords) {
+	inGamut (coords, epsilon) {
 		let rgb = this.to.srgb(coords);
-		return Color.inGamut("srgb", rgb);
+		return Color.inGamut("srgb", rgb, {epsilon: epsilon});
 	},
 	 white: Color.whites.D65,
 


### PR DESCRIPTION
This fixes an issue where when an epsilon threshold is passed to `inGamut`, it is not sent to spaces that implement their own `inGamut`.

Previously, when calling `toGamut`, colors like HSL would not actually be fit to the gamut:

```js
> color = new Color("lab(100% 0 0)").to('hsl')
Color$1 {
  _spaceId: 'hsl',
  toString: [Function: toString],
  coords: [ 32.6238164048059, 493.3464693494261, 99.99822243865972 ],
  alpha: 1
}
> color.toGamut()
Color$1 {
  _spaceId: 'hsl',
  toString: [Function: toString],
  coords: [ 32.6238164048059, 100, 99.99822243865972 ],
  alpha: 1
}
```

Though, I think this exposes another potential issue. When HSL has `inGamut` called on it, it uses the sRGB color space to confirm whether it is in gamut or not, but when `toGamut` is called on it, it then uses HSL. Shouldn't it also use sRGB to fit it in gamut?

```js
> color.toGamut('srgb')
Color$1 {
  _spaceId: 'hsl',
  toString: [Function: toString],
  coords: [ 54.25108421948211, 99.99999999986527, 99.99472645127346 ],
  alpha: 1
}
```

Should `toGamut` use sRGB or HSL? It seems the check and the fitting are inconsistent.

Address at least one issue found in Issue #72 