### PR TITLE
Fix conversion issues with HWB and HSL

### DIFF
--- a/src/spaces/hsl.js
+++ b/src/spaces/hsl.js
@@ -18,7 +18,6 @@ Color.defineSpace({
 	// Adapted from https://en.wikipedia.org/wiki/HSL_and_HSV#From_RGB
 	from: {
 		srgb (rgb) {
-			rgb = rgb.map(c => c * 100);
 			let max = Math.max.apply(Math, rgb);
 			let min = Math.min.apply(Math, rgb);
 			let [r, g, b] = rgb;
@@ -26,7 +25,7 @@ Color.defineSpace({
 			let d = max - min;
 
 			if (d !== 0) {
-				s = d * 100 / (100 - Math.abs(2 * l - 100));
+				s = (l === 0 || l === 1) ? 0 : (max - l) / Math.min(l, 1 - l);
 
 				switch (max) {
 					case r: h = (g - b) / d + (g < b ? 6 : 0); break;
@@ -37,7 +36,7 @@ Color.defineSpace({
 				h = h * 60;
 			}
 
-			return [h, s, l];
+			return [h, s * 100, l * 100];
 		}
 	},
 	// Adapted from https://en.wikipedia.org/wiki/HSL_and_HSV#HSL_to_RGB_alternative

--- a/src/spaces/hwb.js
+++ b/src/spaces/hwb.js
@@ -78,12 +78,12 @@ Color.defineSpace({
 			let sum = w + b;
 			if (sum >= 1) {
 				 let gray = w / sum;
-				 return [h, 0, gray];
+				 return [h, 0, gray * 100];
 			}
 
-			let v = 1 - b;
-			let s = 100 - (100 * w) / (100 - b);
-			return [h, s, v * 100];
+			let v = (1 - b);
+			let s = (v === 0) ? 0 : 1 - w / v;
+			return [h, s * 100, v * 100];
 		},
 
 		hsl (hwb) {


### PR DESCRIPTION
1. HSL: Avoid divide by zero cases
2. HSL: values are in range [0, 1] and scale to 100% at end
3. HWB: Avoid divide by zero cases in HWB
4. HWB: values are in range [0, 1] and scale to 100% at end
5. HWB: Fix case where achromatic HWB colors were not scaled correctly
   when returned as HSV.

Fixes #74