### PR TITLE
get: use the actual package name

### DIFF
--- a/get/index.tpl.html
+++ b/get/index.tpl.html
@@ -37,7 +37,7 @@ Or, if you'd rather just have <code>Color</code> as a global variable, the class
 
 <p>Run:</p>
 
-<pre><code>npm install colorjsio</code></pre>
+<pre><code>npm install colorjs.io</code></pre>
 
 <h2>Custom bundle</h2>
 


### PR DESCRIPTION
Got quite confused by this stuff. Let's fix it.