### PR TITLE
color.js: Do not use window when it does not exist

### DIFF
--- a/color.js
+++ b/color.js
@@ -2,7 +2,9 @@
 // for easier testing and experimentation without building
 import Color, {util} from "./src/main.js";
 
-window.Color = window.Color || Color;
+if (window) {
+	window.Color = window.Color || Color;
+}
 
 // Re-export
 export default Color;

--- a/color.js
+++ b/color.js
@@ -2,7 +2,7 @@
 // for easier testing and experimentation without building
 import Color, {util} from "./src/main.js";
 
-if (window) {
+if (global.window) {
 	window.Color = window.Color || Color;
 }
 


### PR DESCRIPTION
Right now color.js seems to... import poorly in node via `esm` due to this use of `window`. I could change it to `global` so it works everywhere, but I figured it won't be much use in non-browser environments anyways.