### PR TITLE
package.json: Remove duplicate wrong "main"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
 	"name": "colorjs.io",
 	"version": "0.0.3",
 	"description": "Color space agnostic color manipulation library",
-	"main": "color.js",
 	"exports": {
 		"import": "./dist/color.esm.js",
 		"require": "./dist/color.cjs.js",


### PR DESCRIPTION
Turns out #96 was partially caused by a package.json issue -- there actually *is* a CJS version already available, it's just it got masked by this wrong entry!

After this commit `esm` is no longer needed to `require` this package.