### PR TITLE
Add HyAB distance

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -155,7 +155,12 @@ export default class Color {
 		return ret;
 	}
 
-	// Euclidean distance of colors in an arbitrary color space
+	/**
+	 * Euclidean distance of colors in an arbitrary color space
+	 *
+	 * @param {Color} color   - The other color.
+	 * @param {string} space  - Color space to run in.
+	 */
 	distance (color, space = "lab") {
 		color = Color.get(color);
 		space = Color.space(space);
@@ -172,12 +177,23 @@ export default class Color {
 		}, 0));
 	}
 
+	/**
+	 * Color difference (delta E) according to any of the supported methods.
+	 *
+	 * @param {Color} color       - The other color.
+	 * @param {string | Object} o - String specifying the method, or an object specifying both the method and additional options.
+	 */
 	deltaE (color, o = {}) {
 		if (util.isString(o)) {
 			o = {method: o};
 		}
 
-		let {method = Color.defaults.deltaE, ...rest} = o;
+		if (util.isString(Color.defaults.deltaE)) {
+			console.warn("The data structure for Color.defaults.deltaE has changed.");
+			Color.defaults.DeltaE = {method: Color.defaults.DeltaE};
+		}
+
+		let {method, ...rest} = {...Color.defaults.DeltaE, ...o};
 		color = Color.get(color);
 
 		if (this["deltaE" + method]) {
@@ -188,11 +204,15 @@ export default class Color {
 	}
 
 	// 1976 DeltaE. 2.3 is the JND
-	deltaE76 (color) {
-		return this.distance(color, "lab");
+	deltaE76 (color, options = {space: 'lab'}) {
+		return this.distance(color, options.space);
 	}
 
-	// Relative luminance
+	/**
+	 * Relative luminance
+	 * 
+	 * @returns {number}
+	*/
 	get luminance () {
 		// Luminance should actually be retrieved from XYZ with a D65 white point.
 		return Color.chromaticAdaptation(Color.spaces.xyz.white, Color.whites.D65, this.xyz)[1];
@@ -971,7 +991,7 @@ Object.assign(Color, {
 	defaults: {
 		gamutMapping: "lch.chroma",
 		precision: 5,
-		deltaE: "76", // Default deltaE method
+		deltaE: { method: "76" }, // Default deltaE method
 		fallbackSpaces: ["p3", "srgb"]
 	}
 });

--- a/src/deltaE/deltaEHyAB.js
+++ b/src/deltaE/deltaEHyAB.js
@@ -1,0 +1,28 @@
+import Color from "../color.js";
+
+/**
+ * HyAB distance of colors in an Lab-like color space.
+ * Best used for large distances. Claims to outperform even DE2000 at that.
+ * Said to be okay for small distances.
+ * 
+ * @see http://markfairchild.org/PDFs/PAP40.pdf
+ * @param {Color} color           - The other color.
+ * @param {Object} [options=]
+ * @param {string?} options.space - Color space to run in.
+ */
+Color.prototype.distanceHyAB = function (color, {space = "lab"} = {}) {
+    color = Color.get(color);
+    space = Color.space(space);
+    if (!(space.classification && space.classification.includes('labish'))) {
+        throw new TypeError(`${space} does not have a Lab-like layout.`)
+    }
+
+    let coords1 = this[space.id];
+    let coords2 = color[space.id];
+
+    const [dL, da, db] = coords1.map((x, i) => x - coords2[i]);
+
+    return Math.abs(dL) + Math.sqrt(da ** 2 + db ** 2);
+}
+
+Color.statify(["deltaEHyAB"]);

--- a/src/spaces/ictcp.js
+++ b/src/spaces/ictcp.js
@@ -26,6 +26,7 @@ Color.defineSpace({
 		CT: [-0.5, 0.5],	// Full BT.2020 gamut in range [-0.5, 0.5]
 		CP: [-0.5, 0.5]
 	},
+	classification: ['labish'],
 	inGamut: coords => true,
 	// Note that XYZ is relative to D65
 	white: Color.whites.D65,

--- a/src/spaces/jzazbz.js
+++ b/src/spaces/jzazbz.js
@@ -8,7 +8,8 @@ Color.defineSpace({
 		Jz: [0, 1],
 		az: [-0.5, 0.5],
 		bz: [-0.5, 0.5]
-    },
+	},
+	classification: ['labish'],
     inGamut: coords => true,
 	// Note that XYZ is relative to D65
 	white: Color.whites.D65,

--- a/src/spaces/lab.js
+++ b/src/spaces/lab.js
@@ -8,6 +8,7 @@ Color.defineSpace({
 		a: [-100, 100],
 		b: [-100, 100]
 	},
+	classification: ['labish'],
 	inGamut: coords => true,
 	// Assuming XYZ is relative to D50, convert to CIE Lab
 	// from CIE standard, which now defines these as a rational fraction

--- a/src/spaces/oklab.js
+++ b/src/spaces/oklab.js
@@ -8,7 +8,8 @@ Color.defineSpace({
 		L: [ 0, 1],
 		a: [-0.5, 0.5],
 		b: [-0.5, 0.5]
-    },
+	},
+	classification: ['labish'],
     inGamut: coords => true,
 	// Note that XYZ is relative to D65
     white: Color.whites.D65,


### PR DESCRIPTION
This commit adds an HyAB-style distance and a very half-asses system for determining whether a colour space is applicable. Test vectors from the paper if any are yet to be added.

A little JSDoc with types are added where convenient. Some editor plugins (like my VSCode) make use of them, so that might make writing code with cjsio a bit more pleasant. I can’t quite figure out how to describe the statify thing though. 