### PR TITLE
A nitpick on chromaticAdaptation and a bunch of JSDoc

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -516,7 +516,7 @@ export default class Color {
 			return XYZ;
 		}
 
-		let env = {W1, W2, XYZ, options};
+		let env = {W1, W2, XYZ, ...options};
 
 		Color.hooks.run("chromatic-adaptation-start", env);
 


### PR DESCRIPTION
chromaticAdaptation currently has an unused `options` function. The code alludes to `env.M` somehow getting set, so the nature thing I figured was to destructure `options` into the `env`.

The bunch of JSDoc is there because I am finding it really hard to fall asleep. They do make sense to VSCode.