### PR TITLE
Reduce npm package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "colorjs.io",
 	"version": "0.0.4",
 	"description": "Color space agnostic color manipulation library",
+	"files": [
+		"dist/"
+	],
 	"exports": {
 		"import": "./dist/color.esm.js",
 		"require": "./dist/color.cjs.js",


### PR DESCRIPTION
Current `colorjs.io` package is 1.7 MB which is a lot.

By removing website. development configs, etc we can reduce it to 1.2 MB.

If this PR will be accepted, I can find a way to reduce it even further. But it is more complicated, since Rollup creates huge source map files.