### PR TITLE
Remove `.min` files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
-node_modules/
+dist/*.min.js
+dist/*.min.js.map


### PR DESCRIPTION
- [x] `npm` ignores `node_modules/` by default
- [x] We do not use `.min.js` files in npm package. Removing it will reduce size `1.2 MB` → `0.7 MB`.