### PR TITLE
Fix .min cleaning and remove IIFE builds

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-dist/*.min.js
-dist/*.min.js.map

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
 	"version": "0.0.4",
 	"description": "Color space agnostic color manipulation library",
 	"files": [
-		"dist/"
+		"dist/color.cjs.js",
+		"dist/color.cjs.js.map",
+		"dist/color.esm.js",
+		"dist/color.esm.js.map"
 	],
 	"exports": {
 		"import": "./dist/color.esm.js",
-		"require": "./dist/color.cjs.js",
-		"default": "./dist/color.js"
+		"require": "./dist/color.cjs.js"
 	},
 	"main": "./dist/color.cjs.js",
 	"module": "./dist/color.esm.js",


### PR DESCRIPTION
What do you think of removing IIFE build?

I think use case for it is very low:

1. Most of the users use bundlers
2. Quick hacks without bundlers is better to do with ESM build since it is an official way (IIFE was a hack)
3. Removing IIFE will drop other 300 KB on users’s machine and CI. Not to big, but seems like unnecessary resource spending since IIFE use case is extremely low.

In my open source, I do not have IIFE build and had no problems with users asking about it.