### PR TITLE
Fix ESM support in Node.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -188,4 +188,19 @@ gulp.task("bundle", async function () {
 	}
 });
 
-gulp.task("default", gulp.parallel("css", "bundle", "html", "md"));
+gulp.task("mjs", function () {
+	return gulp
+		.src(["./dist/color.esm.js*"])
+		.pipe(
+			rename((path) => {
+				if (path.extname === ".js") {
+					path.extname === ".js.mjs";
+				} else {
+					path.basename = "color.esm.mjs";
+				}
+			})
+		)
+		.pipe(gulp.dest("./dist/"));
+});
+
+gulp.task("default", gulp.parallel("css", "bundle", "mjs", "html", "md"));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -194,7 +194,7 @@ gulp.task("mjs", function () {
 		.pipe(
 			rename((path) => {
 				if (path.extname === ".js") {
-					path.extname === ".js.mjs";
+					path.extname = ".mjs";
 				} else {
 					path.basename = "color.esm.mjs";
 				}

--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
 	"files": [
 		"dist/color.cjs.js",
 		"dist/color.cjs.js.map",
-		"dist/color.esm.js",
-		"dist/color.esm.js.map"
+		"dist/color.esm.mjs",
+		"dist/color.esm.mjs.map"
 	],
 	"exports": {
-		"import": "./dist/color.esm.js",
+		"import": "./dist/color.esm.mjs",
 		"require": "./dist/color.cjs.js"
 	},
 	"main": "./dist/color.cjs.js",
-	"module": "./dist/color.esm.js",
+	"module": "./dist/color.esm.mjs",
 	"directories": {
 		"test": "tests"
 	},


### PR DESCRIPTION
Current package doesn’t work in Node.js with `import` (I need `color.js` to generate image in Node.js script).

```
(node:79791) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
/home/ai/Dev/oklch-picker/node_modules/.pnpm/colorjs.io@0.0.5/node_modules/colorjs.io/dist/color.esm.js:2970
export default Color$1;
```

It happens because Node.js need explicit mark that the file is ESM file (with `package.type = "module"` or with `.mjs` extension).

I decided to add `.esm.mjs` files to npm package (and keep old `.esm.js` on website for URL compatibility).