### PR TITLE
Fix issue where longer logic does not match CSS spec

### DIFF
--- a/src/angles.js
+++ b/src/angles.js
@@ -27,10 +27,10 @@ export function adjust (arc, angles) {
 	else if (arc === "longer") {
 		if (-180 < angleDiff && angleDiff < 180) {
 			if (angleDiff > 0) {
-				a2 += 360;
-			}
-			else {
 				a1 += 360;
+			}
+			else if (angleDiff < 0) {
+				a2 += 360;
 			}
 		}
 	}


### PR DESCRIPTION
It appears that Color.js "longer" hue adjust logic does not match the CSS specification: https://www.w3.org/TR/css-color-4/#hue-longer.

The important difference is that while the spec states in pseudo code:

```js
if (0 < θ₂ - θ₁ < 180) {
  θ₁ += 360;
}
else if (-180 < θ₂ - θ₁ < 0) {
  θ₂ += 360;
}
```

It appears Color.js is using something similar to:

```js
if (0 < θ₂ - θ₁ < 180) {
  θ₂ += 360;
}
else if (-180 < θ₂ - θ₁ <= 0) {
  θ₁ += 360;
}
```