### PR TITLE
Fix circular reference

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -175,13 +175,19 @@ let rollupConfig = {
 		bundle("cjs"),
 		bundle("cjs", {minify: true})
 	],
+	onwarn (warning, rollupWarn) {
+		if (warning.code !== 'CIRCULAR_DEPENDENCY') {
+			rollupWarn(warning);
+		}
+	}
 };
 
 gulp.task("bundle", async function () {
 	for (const bundle of rollupConfig.output) {
 		let b = await rollup.rollup({
 			input: rollupConfig.input,
-			plugins: bundle.plugins
+			plugins: bundle.plugins,
+			onwarn: rollupConfig.onwarn
 		});
 
 		await b.write(bundle);

--- a/src/util.js
+++ b/src/util.js
@@ -1,3 +1,4 @@
+import Color from "./color.js";
 import multiplyMatrices from "./multiply-matrices.js";
 
 /**


### PR DESCRIPTION
util.js should not require `Color` from color.js which requires util.js
This breaks esm packages, and probably other as well.

Fixes #137 