### PR TITLE
Fix package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
 		"src/"
 	],
 	"exports": {
-		"import": "./dist/color.js",
-		"require": "./dist/color.cjs",
+		".": {
+			"import": "./dist/color.js",
+			"require": "./dist/color.cjs"
+		},
 		"./fn": "./src/index-fn.js"
 	},
 	"type": "module",


### PR DESCRIPTION
> `Error [ERR_INVALID_PACKAGE_CONFIG]: Invalid package config node_modules/colorjs.io/package.json. "exports" cannot contain some keys starting with '.' and some not. The exports object must either be an object of package subpath keys or an object of main entry condition name keys only.`