### PR TITLE
Rework subpath and conditional export declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
 		"src/"
 	],
 	"exports": {
-		"import": "./dist/color.js",
-		"require": "./dist/color.cjs",
+		".": {
+			"import": "./dist/color.js",
+			"require": "./dist/color.cjs"
+		},
 		"./fn": "./src/index-fn.js"
 	},
 	"type": "module",


### PR DESCRIPTION
Hey folks! 👋

It looks like `package.json` is mixing conditional and subpath export declarations at the top level. This is not [the recommended approach as per the `node` documentation](https://nodejs.org/api/packages.html#conditional-exports).

Specifically, it recommends the following approach:

```js
{
  "exports": {
    ".": "./index.js",
    "./feature.js": {
      "node": "./feature-node.js",
      "default": "./feature.js"
    }
  }
}
```

The current approach is not well supported with common tools like `webpack`.