### PR TITLE
Fix index-fn reexport collisions

### DIFF
--- a/src/index-fn.js
+++ b/src/index-fn.js
@@ -16,9 +16,15 @@ export {default as distance}  from "./distance.js";
 export {default as equals}    from "./equals.js";
 export {default as contrast}  from "./contrast.js";
 export {default as clone}     from "./clone.js";
-export *                      from "./luminance.js";
-export *                      from "./chromaticity.js";
+export {
+  getLuminance, setLuminance, register as registerLuminance
+}                             from "./luminance.js";
+export {
+  uv, xy, register as registerChromaticity
+}                             from "./chromaticity.js";
 export {default as deltaE}    from "./deltaE.js";
 export *                      from "./deltaE/index.js";
 export *                      from "./variations.js";
-export *                      from "./interpolation.js";
+export {
+  mix, steps, range, isRange, register as registerInterpolation
+}                             from "./interpolation.js";

--- a/src/index-fn.js
+++ b/src/index-fn.js
@@ -17,14 +17,12 @@ export {default as equals}    from "./equals.js";
 export {default as contrast}  from "./contrast.js";
 export {default as clone}     from "./clone.js";
 export {
-  getLuminance, setLuminance, register as registerLuminance
+  getLuminance, setLuminance
 }                             from "./luminance.js";
-export {
-  uv, xy, register as registerChromaticity
-}                             from "./chromaticity.js";
+export {uv, xy}                             from "./chromaticity.js";
 export {default as deltaE}    from "./deltaE.js";
 export *                      from "./deltaE/index.js";
 export *                      from "./variations.js";
 export {
-  mix, steps, range, isRange, register as registerInterpolation
+  mix, steps, range, isRange
 }                             from "./interpolation.js";


### PR DESCRIPTION
This PR renames some re-exports in `index-fn.js`, so that there are no name collisions.

See #171. 