### PR TITLE
Don't import Color class in keywords.js

### DIFF
--- a/src/keywords.js
+++ b/src/keywords.js
@@ -2,7 +2,6 @@
  * Note that this does not include currentColor, transparent,
  * or system colors
  */
-import Color from "./color.js";
 
 // To produce: Visit https://www.w3.org/TR/css-color-4/#named-colors
 // and run in the console:


### PR DESCRIPTION
The `Color` class is being imported in `keywords.js`, without being used anywhere in the file.

This is causing the full compositional API to be included as long as keywords are used, even if the user is making use of just `/fn` functionality.