### PR TITLE
[parse] Trim input, fixes #196

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -4,7 +4,7 @@ import ColorSpace from "./space.js";
 
 // CSS color to Color object
 export default function parse (str) {
-	let env = {str};
+	let env = {"str": str?.trim()};
 	hooks.run("parse-start", env);
 
 	if (env.color) {

--- a/src/parse.js
+++ b/src/parse.js
@@ -4,7 +4,7 @@ import ColorSpace from "./space.js";
 
 // CSS color to Color object
 export default function parse (str) {
-	let env = {"str": str?.trim()};
+	let env = {"str": String(str)?.trim()};
 	hooks.run("parse-start", env);
 
 	if (env.color) {


### PR DESCRIPTION
Fixes #196 
Parse() should trim input strings to avoid edge cases where leading and trailing spaces cause type error.

```js
let color1 = new Color("red"); // works
let color2 = new Color(" red"); // this doesn't
```

