### PR TITLE
[contrast / deltaPhi]

### DIFF
--- a/src/contrast/deltaPhi.js
+++ b/src/contrast/deltaPhi.js
@@ -6,7 +6,7 @@
 
 import getColor from "../getColor.js";
 import {getLuminance} from "../luminance.js";
-import lab-d65 from "../spaces/lab-d65.js";
+import lab_d65 from "../spaces/lab-d65.js";
 
 const phi = Math.pow(5, 0.5) * 0.5 + 0.5; // Math.phi can be used if Math.js
 
@@ -14,8 +14,8 @@ export default function contrastDeltaPhi (color1, color2) {
 	color1 = getColor(color1);
 	color2 = getColor(color2);
 
-	let Lstr1 = get(color1, [lab-d65, "l"]);
-	let Lstr2 = get(color2, [lab-d65, "l"]);
+	let Lstr1 = get(color1, [lab_d65, "l"]);
+	let Lstr2 = get(color2, [lab_d65, "l"]);
 
 	let deltaPhiStar = Math.abs(Math.pow(Lstr1,phi) - Math.pow(Lstr2,phi));
 

--- a/src/contrast/deltaPhi.js
+++ b/src/contrast/deltaPhi.js
@@ -1,0 +1,34 @@
+// Delta Phi Star perceptual lightness contrast
+// The (difference between two Lstars each raised to phi) raised to (1/phi)
+// Symmetric, does not matter which is foreground and which is background
+
+
+import getColor from "../getColor.js";
+import {getLuminance} from "../luminance.js";
+
+// from CIE standard, which now defines these as rational fractions
+const epsilon = 216/24389;  // 6^3/29^3
+const kappa = 24389/27;    // 29^3/3^3
+
+const phi = Math.pow(5, 0.5) * 0.5 + 0.5; // Math.phi can be used if Math.js
+
+// CIE Y to Lstar
+function YtoLstar(Y) {
+	// Assuming Y is relative to D65 ref = 1, convert to CIE Lstar
+	return Y > epsilon ? 116 * Math.cbrt(Y) - 16 : kappa * Y;
+	// L* in range [0,100]
+}
+
+export default function contrastDeltaPhi (color1, color2) {
+	color1 = getColor(color1);
+	color2 = getColor(color2);
+
+	let Lstr1 = YtoLstar(Math.max(getLuminance(color1), 0));
+	let Lstr2 = YtoLstar(Math.max(getLuminance(color2), 0));
+
+	let deltaPhiStar = Math.abs(Math.pow(Lstr1,phi) - Math.pow(Lstr2,phi));
+
+	let contrast = Math.pow(deltaPhiStar, (1 / phi)) * Math.SQRT2 - 40;
+
+	return (contrast < 7.5) ? 0.0 : contrast ;
+};

--- a/src/contrast/deltaPhi.js
+++ b/src/contrast/deltaPhi.js
@@ -1,30 +1,21 @@
 // Delta Phi Star perceptual lightness contrast
+// See https://github.com/Myndex/deltaphistar
 // The (difference between two Lstars each raised to phi) raised to (1/phi)
 // Symmetric, does not matter which is foreground and which is background
 
 
 import getColor from "../getColor.js";
 import {getLuminance} from "../luminance.js";
-
-// from CIE standard, which now defines these as rational fractions
-const epsilon = 216/24389;  // 6^3/29^3
-const kappa = 24389/27;    // 29^3/3^3
+import lab-d65 from "../spaces/lab-d65.js";
 
 const phi = Math.pow(5, 0.5) * 0.5 + 0.5; // Math.phi can be used if Math.js
-
-// CIE Y to Lstar
-function YtoLstar(Y) {
-	// Assuming Y is relative to D65 ref = 1, convert to CIE Lstar
-	return Y > epsilon ? 116 * Math.cbrt(Y) - 16 : kappa * Y;
-	// L* in range [0,100]
-}
 
 export default function contrastDeltaPhi (color1, color2) {
 	color1 = getColor(color1);
 	color2 = getColor(color2);
 
-	let Lstr1 = YtoLstar(Math.max(getLuminance(color1), 0));
-	let Lstr2 = YtoLstar(Math.max(getLuminance(color2), 0));
+	let Lstr1 = get(color1, [lab-d65, "l"]);
+	let Lstr2 = get(color2, [lab-d65, "l"]);
 
 	let deltaPhiStar = Math.abs(Math.pow(Lstr1,phi) - Math.pow(Lstr2,phi));
 

--- a/src/contrast/index.js
+++ b/src/contrast/index.js
@@ -3,3 +3,4 @@ export {default as contrastAPCA} from "./APCA.js";
 export {default as contrastMichelson} from "./Michelson.js";
 export {default as contrastWeber} from "./Weber.js";
 export {default as contrastLstar} from "./Lstar.js";
+export {default as contrastDeltaPhi} from "./deltaPhi.js";

--- a/src/spaces/index-fn.js
+++ b/src/spaces/index-fn.js
@@ -1,6 +1,7 @@
 export {default as XYZ_D65} from "./xyz-d65.js";
 export {default as XYZ_D50} from "./xyz-d50.js";
 export {default as XYZ_ABS_D65} from "./xyz-abs-d65.js";
+export {default as Lab_D65} from "./lab-d65.js";
 export {default as Lab} from "./lab.js";
 export {default as LCH} from "./lch.js";
 export {default as sRGB_Linear} from "./srgb-linear.js";

--- a/src/spaces/lab-d65.js
+++ b/src/spaces/lab-d65.js
@@ -1,0 +1,74 @@
+import ColorSpace from "../space.js";
+import {WHITES} from "../adapt.js";
+import xyz_d65 from "./xyz-d65.js";
+
+// κ * ε  = 2^3 = 8
+const ε = 216/24389;  // 6^3/29^3 == (24/116)^3
+const ε3 = 24/116;
+const κ = 24389/27;   // 29^3/3^3
+
+let white = WHITES.D65;
+
+export default new ColorSpace({
+	id: "lab-d65",
+	name: "Lab D65",
+	coords: {
+		l: {
+			refRange: [0, 100],
+			name: "L"
+		},
+		a: {
+			refRange: [-125, 125]
+		},
+		b: {
+			refRange: [-125, 125]
+		}
+	},
+
+	// Assuming XYZ is relative to D65, convert to CIE Lab
+	// from CIE standard, which now defines these as a rational fraction
+	white,
+
+	base: xyz_d65,
+	// Convert D65-adapted XYZ to Lab
+	//  CIE 15.3:2004 section 8.2.1.1
+	fromBase (XYZ) {
+		// compute xyz, which is XYZ scaled relative to reference white
+		let xyz = XYZ.map((value, i) => value / white[i]);
+
+		// now compute f
+		let f = xyz.map(value => value > ε ? Math.cbrt(value) : (κ * value + 16)/116);
+
+		return [
+			(116 * f[1]) - 16, 	 // L
+			500 * (f[0] - f[1]), // a
+			200 * (f[1] - f[2])  // b
+		];
+	},
+	// Convert Lab to D65-adapted XYZ
+	// Same result as CIE 15.3:2004 Appendix D although the derivation is different
+	// http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+	toBase (Lab) {
+		// compute f, starting with the luminance-related term
+		let f = [];
+		f[1] = (Lab[0] + 16)/116;
+		f[0] = Lab[1]/500 + f[1];
+		f[2] = f[1] - Lab[2]/200;
+
+		// compute xyz
+		let xyz = [
+			f[0]   > ε3  ?  Math.pow(f[0], 3)            : (116*f[0]-16)/κ,
+			Lab[0] > 8   ?  Math.pow((Lab[0]+16)/116, 3) : Lab[0]/κ,
+			f[2]   > ε3  ?  Math.pow(f[2], 3)            : (116*f[2]-16)/κ
+		];
+
+		// Compute XYZ by scaling xyz by reference white
+		return xyz.map((value, i) => value * white[i]);
+	},
+
+	formats: {
+		"lab": {
+			coords: ["<percentage> | <number>", "<number>", "<number>"],
+		}
+	}
+});


### PR DESCRIPTION
New contrast module, deltaPhiStar 𝜟𝜱✴︎

https://github.com/Myndex/deltaphistar

This version is approximately aligned with APCA light mode.

deltaPhiStar 𝜟𝜱✴︎ is symmetric and does not consider polarity. It is intended as a general purpose perceptual contrast method, which is similar to APCA, and useable for high spatial frequency stimuli on self-illuminated monitors.

May be particularly useful for dataviz elements.
