### PR TITLE
support the premultiplied option in mix

### DIFF
--- a/src/interpolation.js
+++ b/src/interpolation.js
@@ -32,9 +32,9 @@ export function mix (c1, c2, p = .5, o = {}) {
 		[p, o] = [.5, p];
 	}
 
-	let {space, outputSpace} = o;
+	let {space, outputSpace, premultiplied} = o;
 
-	let r = range(c1, c2, {space, outputSpace});
+	let r = range(c1, c2, {space, outputSpace, premultiplied});
 	return r(p);
 }
 


### PR DESCRIPTION
`range` supports the `premultiplied` option which is not supported by `mix`, even though `mix` is implemented on top of `range`. I think it makes sense to support it in `mix` as well.