### PR TITLE
[ci] Update conditions for dtslint workflow run

### DIFF
--- a/.github/workflows/test-types.yml
+++ b/.github/workflows/test-types.yml
@@ -1,5 +1,11 @@
 name: Test Type Definitions
-on: pull_request
+on:
+  push:
+    branches: [main]
+    paths: [types/**/*]
+  pull_request:
+    branches: [main]
+    paths: [types/**/*]
 
 jobs:
   test:
@@ -10,7 +16,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "12"
-
 
       - run: npm install
       - run: npm run dtslint


### PR DESCRIPTION
The workflow added in #221 only runs on pull requests, not on pushes. This means that anyone directly pushing to the main branch without creating a pull request skips the job to run `dtslint`.

This PR updates the conditions so that it runs on both pushes and pull requests, as well as changes the conditions so that it only runs when files in the types/ folder are modified.