### PR TITLE
Adjust format type and add serialize type test.

### DIFF
--- a/types/src/serialize.d.ts
+++ b/types/src/serialize.d.ts
@@ -1,5 +1,5 @@
 import { ColorTypes } from "./color";
-import { Format } from "./space"
+import { Format } from "./space";
 
 export interface Options {
 	precision?: number | undefined;

--- a/types/src/space.d.ts
+++ b/types/src/space.d.ts
@@ -13,6 +13,7 @@ export interface Format {
 	toGamut?: boolean | undefined;
 	commas?: boolean | undefined;
 	lastAlpha?: boolean | undefined;
+	noAlpha?: boolean | undefined;
 	test?: ((str: string) => boolean) | undefined;
 	parse?: ((str: string) => ColorConstructor) | undefined;
 	serialize?: ((coords: Coords, alpha: number, opts?: Record<string, any>) => string) | undefined;

--- a/types/test/serialize.ts
+++ b/types/test/serialize.ts
@@ -9,3 +9,4 @@ serialize(new Color("red")); // $ExpectType string
 serialize("red", {}); // $ExpectType string
 serialize("red", { precision: 5, format: "default", inGamut: false }); // $ExpectType string
 serialize("red", { precision: 5, format: "default", inGamut: false, foo: "bar" }); // $ExpectType string
+serialize("red", { format: { name: "CustomFormat", id: "custom-format" } }); // $ExpectType string


### PR DESCRIPTION
This adds a type test for the change in https://github.com/LeaVerou/color.js/commit/d0ab5d1fe61e43f37386f7634a0cc4aee15e2302, and also adjusts the `Format` type to account for the change in https://github.com/LeaVerou/color.js/commit/667c19a60d5a6c8c81e9d07bd217ebda385a10b2.