### PR TITLE
Fix bundler compatibility

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -119,10 +119,6 @@ export default class Color {
 	}
 
 	static defineFunction (name, code, o = code) {
-		if (arguments.length === 1) {
-			[name, code, o] = [arguments[0].name, arguments[0], arguments[0]];
-		}
-
 		let {instance = true, returns} = o;
 
 		let func = function (...args) {
@@ -167,12 +163,6 @@ export default class Color {
 	static extend (exports) {
 		if (exports.register) {
 			exports.register(Color);
-		}
-		else if (exports.default) {
-			Color.defineFunction(exports.default.name, exports.default);
-		}
-		else if (typeof exports === "function") {
-			Color.defineFunction(exports);
 		}
 		else {
 			// No register method, just add the module's functions

--- a/src/index.js
+++ b/src/index.js
@@ -5,18 +5,18 @@ import Color from "./color.js";
 import "./spaces/index.js";
 
 // Import all DeltaE methods
-import * as deltaE from "./deltaE.js";
+import deltaE from "./deltaE.js";
 import * as deltaEMethods from "./deltaE/index.js";
 
 Color.extend(deltaEMethods);
-Color.extend(deltaE);
+Color.extend({deltaE});
 
 // Import optional modules
 import * as variations from "./variations.js";
 Color.extend(variations);
 
 import contrast from "./contrast.js";
-Color.extend(contrast);
+Color.extend({contrast});
 
 import * as chromaticity from "./chromaticity.js";
 Color.extend(chromaticity);

--- a/types/src/color.d.ts
+++ b/types/src/color.d.ts
@@ -90,7 +90,6 @@ declare class Color {
 		alpha: number
 	): Color;
 
-	static defineFunction(code: DefineFunctionHybrid): void;
 	static defineFunction(name: string, code: DefineFunctionHybrid): void;
 	static defineFunction(
 		name: string,
@@ -102,9 +101,7 @@ declare class Color {
 
 	static extend(
 		exports:
-			| DefineFunctionHybrid
 			| { register: (color: typeof Color) => void }
-			| { default: DefineFunctionHybrid }
 			| Record<string, DefineFunctionHybrid>
 	): void;
 


### PR DESCRIPTION
Fixes #235 

It's not safe to access function name in bundled apps, such as (reproduced in):
- vite@3.2.2 / esbuild@0.15.12
- cra@5.0.1 / terser@5.15.1 
- next@13.0.1 / swc@1.2

This bug could also reproduced in `dist/color.global.min.js` (main branch, bundled by terser):

```
// eval dist/color.global.min.js 
Color.prototype.contrast -> undefined
```
