### PR TITLE
[contrast] Add re-export of `src/contrast/index.js` to `src/index-fn.js`

### DIFF
--- a/src/index-fn.js
+++ b/src/index-fn.js
@@ -21,6 +21,7 @@ export {
   getLuminance, setLuminance
 }                             from "./luminance.js";
 export {uv, xy}                             from "./chromaticity.js";
+export *                      from "./contrast/index.js";
 export {default as deltaE}    from "./deltaE.js";
 export *                      from "./deltaE/index.js";
 export *                      from "./variations.js";

--- a/types/src/index-fn.d.ts
+++ b/types/src/index-fn.d.ts
@@ -22,6 +22,7 @@ export { uv, xy } from "./chromaticity";
 export { default as deltaE } from "./deltaE";
 export { mix, steps, range, isRange } from "./interpolation";
 
+export * from "./contrast/index";
 export * from "./deltaE/index";
 export * from "./variations";
 export * from "./spaces/index-fn";

--- a/types/test/contrast.ts
+++ b/types/test/contrast.ts
@@ -1,5 +1,6 @@
 import Color from "colorjs.io/src/color";
 import contrast from "colorjs.io/src/contrast";
+import { contrastAPCA } from "colorjs.io/src/index-fn";
 
 const c1 = new Color("red");
 const c2 = new Color("blue");
@@ -13,3 +14,6 @@ contrast(c1, c2);
 
 contrast(c1, c2, "APCA"); // $ExpectType number
 contrast(c1, c2, { algorithm: "APCA" }); // $ExpectType number
+
+// Make sure that contrast methods are properly re-exported
+contrastAPCA("red", "blue"); // $ExpectType number


### PR DESCRIPTION
Adds a missing re-export of the contrast functions to `src/index-fn.js`.

From <https://github.com/LeaVerou/color.js/pull/162#issuecomment-1306232139>:

> > Is it correct that the named contrast functions e.g. `contrastAPCA` are not included in `colorjs.io/fn`?
> 
> They should be. If not, it's a bug. But I believe they are exported en masse from contrast/index-fn.js, so if you're searching the source for contrastAPCA it won't find anything.

I've updated the TypeScript tests to make sure the contrast methods are importable through `src/index-fn.js`, but I'm not sure if there's anything to change for the tests in `tests/`.