### PR TITLE
Fix parameter type of Color.defineFunction

### DIFF
--- a/types/src/color.d.ts
+++ b/types/src/color.d.ts
@@ -37,7 +37,7 @@ export type ColorTypes = Color | ColorObject | ColorConstructor | string;
 
 export type DefineFunctionCode = (
 	...args: any[]
-) => ColorTypes | ColorTypes[] | ((...args: any[]) => ColorTypes);
+) => ColorTypes | ColorTypes[] | ((...args: any[]) => ColorTypes) | any;
 
 export interface DefineFunctionOptions {
 	instance?: boolean | undefined;

--- a/types/src/color.d.ts
+++ b/types/src/color.d.ts
@@ -35,9 +35,7 @@ export interface ColorConstructor {
 
 export type ColorTypes = Color | ColorObject | ColorConstructor | string;
 
-export type DefineFunctionCode = (
-	...args: any[]
-) => ColorTypes | ColorTypes[] | ((...args: any[]) => ColorTypes) | any;
+export type DefineFunctionCode = (...args: any[]) => any;
 
 export interface DefineFunctionOptions {
 	instance?: boolean | undefined;


### PR DESCRIPTION
The function may return something else. For example: `deltaE` returns a number.