### PR TITLE
[types] Merge `Color` types

### DIFF
--- a/types/src/index.d.ts
+++ b/types/src/index.d.ts
@@ -1,6 +1,6 @@
-import { uv, xy } from "../src/chromaticity";
-import ColorImport, { ToColorPrototype } from "../src/color";
-import contrast from "../src/contrast";
+import { uv, xy } from "./chromaticity";
+import Color from "./color";
+import contrast from "./contrast";
 import {
 	contrastWCAG21,
 	contrastAPCA,
@@ -8,8 +8,8 @@ import {
 	contrastWeber,
 	contrastLstar,
 	contrastDeltaPhi,
-} from "../src/contrast/index";
-import deltaE from "../src/deltaE";
+} from "./contrast/index";
+import deltaE from "./deltaE";
 import {
 	deltaE76,
 	deltaECMC,
@@ -17,77 +17,73 @@ import {
 	deltaEJz,
 	deltaEITP,
 	deltaEOK,
-} from "../src/deltaE/index";
-import { mix, range, steps } from "../src/interpolation";
-import { getLuminance } from "../src/luminance";
-import { lighten, darken } from "../src/variations";
+} from "./deltaE/index";
+import { mix, range, steps } from "./interpolation";
+import { getLuminance } from "./luminance";
+import { lighten, darken } from "./variations";
 
-declare namespace Color {
-	// contrast
-	export { contrast };
-	// contrastMethods
-	export {
-		contrastWCAG21,
-		contrastAPCA,
-		contrastMichelson,
-		contrastWeber,
-		contrastLstar,
-		contrastDeltaPhi,
-	};
-	// deltaE
-	export {
-		deltaE,
-		deltaE76,
-		deltaECMC,
-		deltaE2000,
-		deltaEJz,
-		deltaEITP,
-		deltaEOK,
-	};
-	// interpolation
-	export { mix, range, steps };
-	// variations
-	export { lighten, darken };
-}
+// Augment existing Color object
+declare module "./color" {
+	export default class Color {
+		// chromaticity
+		uv: ToColorPrototype<typeof uv>;
+		xy: ToColorPrototype<typeof xy>;
 
-declare class Color extends ColorImport {
-	// chromaticity
-	uv: ToColorPrototype<typeof uv>;
-	xy: ToColorPrototype<typeof xy>;
+		// contrast
+		contrast: ToColorPrototype<typeof contrast>;
+		static contrast: typeof contrast;
 
-	// contrast
-	contrast: ToColorPrototype<typeof contrast>;
+		// contrastMethods
+		contrastWCAG21: ToColorPrototype<typeof contrastWCAG21>;
+		contrastAPCA: ToColorPrototype<typeof contrastAPCA>;
+		contrastMichelson: ToColorPrototype<typeof contrastMichelson>;
+		contrastWeber: ToColorPrototype<typeof contrastWeber>;
+		contrastLstar: ToColorPrototype<typeof contrastLstar>;
+		contrastDeltaPhi: ToColorPrototype<typeof contrastDeltaPhi>;
 
-	// contrastMethods
-	contrastWCAG21: ToColorPrototype<typeof contrastWCAG21>;
-	contrastAPCA: ToColorPrototype<typeof contrastAPCA>;
-	contrastMichelson: ToColorPrototype<typeof contrastMichelson>;
-	contrastWeber: ToColorPrototype<typeof contrastWeber>;
-	contrastLstar: ToColorPrototype<typeof contrastLstar>;
-	contrastDeltaPhi: ToColorPrototype<typeof contrastDeltaPhi>;
+		static contrastWCAG21: typeof contrastWCAG21;
+		static contrastAPCA: typeof contrastAPCA;
+		static contrastMichelson: typeof contrastMichelson;
+		static contrastWeber: typeof contrastWeber;
+		static contrastLstar: typeof contrastLstar;
+		static contrastDeltaPhi: typeof contrastDeltaPhi;
 
-	// deltaE
-	deltaE: ToColorPrototype<typeof deltaE>;
-	deltaE76: ToColorPrototype<typeof deltaE76>;
-	deltaECMC: ToColorPrototype<typeof deltaECMC>;
-	deltaE2000: ToColorPrototype<typeof deltaE2000>;
-	deltaEJz: ToColorPrototype<typeof deltaEJz>;
-	deltaEITP: ToColorPrototype<typeof deltaEITP>;
-	deltaEOK: ToColorPrototype<typeof deltaEOK>;
+		// deltaE
+		deltaE: ToColorPrototype<typeof deltaE>;
+		deltaE76: ToColorPrototype<typeof deltaE76>;
+		deltaECMC: ToColorPrototype<typeof deltaECMC>;
+		deltaE2000: ToColorPrototype<typeof deltaE2000>;
+		deltaEJz: ToColorPrototype<typeof deltaEJz>;
+		deltaEITP: ToColorPrototype<typeof deltaEITP>;
+		deltaEOK: ToColorPrototype<typeof deltaEOK>;
 
-	// interpolation
-	mix: ToColorPrototype<typeof mix>;
-	range: ToColorPrototype<typeof range>;
-	steps: ToColorPrototype<typeof steps>;
+		static deltaE: typeof deltaE;
+		static deltaE76: typeof deltaE76;
+		static deltaECMC: typeof deltaECMC;
+		static deltaE2000: typeof deltaE2000;
+		static deltaEJz: typeof deltaEJz;
+		static deltaEITP: typeof deltaEITP;
+		static deltaEOK: typeof deltaEOK;
 
-	// luminance
-	get luminance(): ReturnType<typeof getLuminance>;
-	// the definition for this set in the orignial code like it doesn't actually use the parameter?
-	set luminance(_: number);
+		// interpolation
+		mix: ToColorPrototype<typeof mix>;
+		range: ToColorPrototype<typeof range>;
+		steps: ToColorPrototype<typeof steps>;
+		static mix: typeof mix;
+		static range: typeof range;
+		static steps: typeof steps;
 
-	// variations
-	lighten: ToColorPrototype<typeof lighten>;
-	darken: ToColorPrototype<typeof darken>;
+		// luminance
+		get luminance(): ReturnType<typeof getLuminance>;
+		// the definition for this set in the orignial code like it doesn't actually use the parameter?
+		set luminance(_: number);
+
+		// variations
+		lighten: ToColorPrototype<typeof lighten>;
+		darken: ToColorPrototype<typeof darken>;
+		static lighten: typeof lighten;
+		static darken: typeof darken;
+	}
 }
 
 export default Color;

--- a/types/test/color-index.ts
+++ b/types/test/color-index.ts
@@ -1,0 +1,10 @@
+import Color from "colorjs.io/src/index";
+
+// Make sure that the module augmentation is working
+const color1 = new Color("red");
+const color2 = color1.to("srgb");
+const color3: Color = color2;
+
+color1.contrast;
+color2.contrast;
+color3.contrast;

--- a/types/test/color.ts
+++ b/types/test/color.ts
@@ -19,4 +19,8 @@ color.clone(); // $ExpectType Color
 color.display();
 color.display({ space: "srgb" });
 
+// The module augmentation shouldn't be happening with this import, so this property shouldn't exist
+// @ts-expect-error
+Color.contrast;
+
 // Most other color methods are those defined in other files, so they aren't tested her

--- a/types/test/color.ts
+++ b/types/test/color.ts
@@ -19,8 +19,4 @@ color.clone(); // $ExpectType Color
 color.display();
 color.display({ space: "srgb" });
 
-// The module augmentation shouldn't be happening with this import, so this property shouldn't exist
-// @ts-expect-error
-Color.contrast;
-
-// Most other color methods are those defined in other files, so they aren't tested her
+// Most other color methods are those defined in other files, so they aren't tested here


### PR DESCRIPTION
Closes #258

The types originally had two definitions for the `Color` type which weren't interchangeable. This PR changes the types to more accurately reflect the original JS by augmenting the existing `Color` type when `src/index.d.ts` is imported.

There is a problem with how I've done this right now: the module augmentation is happening even when the normal `src/color.d.ts` version of the class is imported. I'm not sure how this is happening without `src/index.d.ts` even being referenced, so I'll have to debug that when I get the chance. Any help to make sure the augmentation only happens when `src/index.d.ts` is imported would be appreciated.

You can look at the failing test to see the problem: <https://github.com/LeaVerou/color.js/pull/259/files#diff-5bb8dd015c2660f438205df14840aa404517154744bcf054146734f0d5f8ad26>