### PR TITLE
Correct rec2100-hlg, #190

### DIFF
--- a/src/spaces/rec2020-linear.js
+++ b/src/spaces/rec2020-linear.js
@@ -22,5 +22,8 @@ export default new RGBColorSpace({
 	name: "Linear REC.2020",
 	white: "D65",
 	toXYZ_M,
-	fromXYZ_M
+	fromXYZ_M,
+	formats: {
+		color: {},
+	}
 });


### PR DESCRIPTION
Fix wildly incorrect REC.2100 HLG encoding and decoding:

 - Parts of the code assumed [0,1] was SDR range, others that it was HDR range
 - The EOTF and OEFT from BT.2390-10 were the wrong way round
 - implemented a scaling factor to place 18% grey at 38% and SDR white at 75%
 - also fixed parse error in `color(rec2020-linear ...)`