### PR TITLE
Fix Rec 2100 HLG algorithm

### DIFF
--- a/src/spaces/rec2100-hlg.js
+++ b/src/spaces/rec2100-hlg.js
@@ -27,7 +27,7 @@ export default new RGBColorSpace({
 			if (val <= 0.5) {
 				return (val ** 2) / 3 * scale;
 			}
-			return Math.exp(((val - c) / a) + b) / 12 * scale;
+			return ((Math.exp((val - c) / a) + b) / 12) * scale;
 		});
 	},
 	fromBase (RGB) {


### PR DESCRIPTION
As you can see, the round trip is busted:

```js
> new Color('srgb', [0.6, 0.6, 0.6]).to('rec2100hlg').to('srgb').toString()
'rgb(58.775% 58.775% 58.775%)'
```

With the proposed fix:

```js
> new Color('srgb', [0.6, 0.6, 0.6]).to('rec2100hlg').to('srgb').toString()
'rgb(60% 60% 60%)'
```
