### PR TITLE
Allow to extend the deltaE methods

### DIFF
--- a/src/deltaE.js
+++ b/src/deltaE.js
@@ -1,7 +1,7 @@
 import getColor from "./getColor.js";
 import defaults from "./defaults.js";
 import {isString} from "./util.js";
-import * as deltaEMethods from "./deltaE/index.js";
+import deltaEMethods from "./deltaE/index.js";
 
 export default function deltaE (c1, c2, o = {}) {
 	if (isString(o)) {

--- a/src/deltaE/index.js
+++ b/src/deltaE/index.js
@@ -4,3 +4,12 @@ export {default as deltaE2000} from "./deltaE2000.js";
 export {default as deltaEJz} from "./deltaEJz.js";
 export {default as deltaEITP} from "./deltaEITP.js";
 export {default as deltaEOK} from "./deltaEOK.js";
+
+export default {
+	deltaE76,
+	deltaECMC,
+	deltaE2000,
+	deltaEJz,
+	deltaEITP,
+	deltaEOK,
+};

--- a/src/index-fn.js
+++ b/src/index-fn.js
@@ -24,6 +24,7 @@ export {uv, xy}                             from "./chromaticity.js";
 export *                      from "./contrast/index.js";
 export {default as deltaE}    from "./deltaE.js";
 export *                      from "./deltaE/index.js";
+export {default as deltaEMethods} from "./deltaE/index.js";
 export *                      from "./variations.js";
 export {
   mix, steps, range, isRange

--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,11 @@ import "./spaces/index.js";
 
 // Import all DeltaE methods
 import deltaE from "./deltaE.js";
-import * as deltaEMethods from "./deltaE/index.js";
+import deltaEMethods from "./deltaE/index.js";
 
 Color.extend(deltaEMethods);
 Color.extend({deltaE});
+Object.assign(Color, {deltaEMethods});
 
 // Import optional modules
 import * as variations from "./variations.js";

--- a/types/src/deltaE/index.d.ts
+++ b/types/src/deltaE/index.d.ts
@@ -1,10 +1,13 @@
-export type Methods = keyof typeof import(".") extends `deltaE${infer Method}`
-	? Method
-	: string;
-
 export { default as deltaE76 } from "./deltaE76";
 export { default as deltaECMC } from "./deltaECMC";
 export { default as deltaE2000 } from "./deltaE2000";
 export { default as deltaEJz } from "./deltaEJz";
 export { default as deltaEITP } from "./deltaEITP";
 export { default as deltaEOK } from "./deltaEOK";
+
+declare const deltaEMethods: Omit<typeof import("./index"), "default">;
+export default deltaEMethods;
+
+export type Methods = keyof typeof deltaEMethods extends `deltaE${infer Method}`
+	? Method
+	: string;

--- a/types/src/index-fn.d.ts
+++ b/types/src/index-fn.d.ts
@@ -24,5 +24,6 @@ export { mix, steps, range, isRange } from "./interpolation";
 
 export * from "./contrast/index";
 export * from "./deltaE/index";
+export { default as deltaEMethods } from "./deltaE/index";
 export * from "./variations";
 export * from "./spaces/index-fn";

--- a/types/src/index.d.ts
+++ b/types/src/index.d.ts
@@ -10,7 +10,7 @@ import {
 	contrastDeltaPhi,
 } from "./contrast/index";
 import deltaE from "./deltaE";
-import {
+import deltaEMethods, {
 	deltaE76,
 	deltaECMC,
 	deltaE2000,
@@ -64,6 +64,7 @@ declare module "./color" {
 		static deltaEJz: typeof deltaEJz;
 		static deltaEITP: typeof deltaEITP;
 		static deltaEOK: typeof deltaEOK;
+		static deltaEMethods: typeof deltaEMethods;
 
 		// interpolation
 		mix: ToColorPrototype<typeof mix>;


### PR DESCRIPTION
```js
import Color from "colorjs.io";
Color.deltaEMethods.deltaECustom = (color, sample) => { ... };
```

```js
import {deltaEMethods} from "colorjs.io/fn";
deltaEMethods.deltaECustom = (color, sample) => { ... };
```