### PR TITLE
[types] Fix clone signature

### DIFF
--- a/types/src/clone.d.ts
+++ b/types/src/clone.d.ts
@@ -1,3 +1,3 @@
-import Color from "./color";
+import Color, { ColorObject } from "./color";
 
-export default function clone(color: Color): Color;
+export default function clone(color: Color | ColorObject): ColorObject;

--- a/types/test/clone.ts
+++ b/types/test/clone.ts
@@ -1,7 +1,14 @@
 import Color from "colorjs.io/src/color";
 import clone from "colorjs.io/src/clone";
+import { sRGB } from "colorjs.io/src/spaces/index-fn";
 
 // @ts-expect-error
 clone();
 
-clone(new Color("red")); // $ExpectType Color
+clone(new Color("red")); // $ExpectType ColorObject
+// $ExpectType ColorObject
+clone({
+	space: sRGB,
+	coords: [0, 0, 0],
+	alpha: 1,
+});


### PR DESCRIPTION
Closes #288

Fixes the types for the `clone` function. The function only returns a few keys from the passed object, not a new class:

<https://github.com/LeaVerou/color.js/blob/e939c7cc70b473a9bfe07fe9d8c4c1c46ef3f754/src/clone.js#L2-L6>