### PR TITLE
Fix incorrect type definition for Range

### DIFF
--- a/types/src/interpolation.d.ts
+++ b/types/src/interpolation.d.ts
@@ -2,7 +2,7 @@ import Color, { ColorTypes } from "./color";
 import ColorSpace from "./space";
 import { Methods } from "./deltaE/index";
 
-export type Range = ((percentage: number) => number) & {
+export type Range = ((percentage: number) => Color) & {
 	rangeArgs: { colors: [Color, Color]; options: Record<string, any> };
 };
 


### PR DESCRIPTION
The function represented by Range should return a Color, not a number.

Fixes #298.