### PR TITLE
Fix oklch and oklab colorspace names

### DIFF
--- a/src/spaces/oklab.js
+++ b/src/spaces/oklab.js
@@ -29,7 +29,7 @@ const LabtoLMS_M = [
 
 export default new ColorSpace({
 	id: "oklab",
-    name: "OKLab",
+    name: "Oklab",
     coords: {
 		l: {
 			refRange: [0, 1],

--- a/src/spaces/oklch.js
+++ b/src/spaces/oklch.js
@@ -4,7 +4,7 @@ import {constrain as constrainAngle} from "../angles.js";
 
 export default new ColorSpace({
 	id: "oklch",
-	name: "OKLCh",
+	name: "Oklch",
 	coords: {
 		l: {
 			refRange: [0, 1],


### PR DESCRIPTION
Change the oklch and oklab colorspace names so they align with the CSS Color Level 4 spec and the original oklab article.

https://www.w3.org/TR/css-color-4/
https://bottosson.github.io/posts/oklab/