### PR TITLE
Add verbose option to parse()

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -5,7 +5,7 @@ import ColorSpace from "./space.js";
 /**
  * Convert a CSS Color string to a color object
  * @param {string} str
- * @param {object} options
+ * @param {object} [options]
  * @param {object} [options.meta] - Object for additional information about the parsing
  * @returns { Color } }
  */

--- a/src/parse.js
+++ b/src/parse.js
@@ -6,16 +6,15 @@ import ColorSpace from "./space.js";
  * Convert a CSS Color string to a color object
  * @param {string} str
  * @param {object} options
- * @param {boolean} options.verbose - If true, return an object with more information
- * @returns { Color | { color: Color, formatId: string } }
+ * @param {object} [options.meta] - Object for additional information about the parsing
+ * @returns { Color } }
  */
-export default function parse (str, {verbose} = {}) {
+export default function parse (str, {meta} = {}) {
 	let env = {"str": String(str)?.trim()};
 	hooks.run("parse-start", env);
 
 	if (env.color) {
-		let color = env.color;
-		return verbose? {color} : env.color;
+		return env.color;
 	}
 
 	env.parsed = util.parseFunction(env.str);
@@ -39,8 +38,11 @@ export default function parse (str, {verbose} = {}) {
 						// If less <number>s or <percentage>s are provided than parameters that the colorspace takes, the missing parameters default to 0. (This is particularly convenient for multichannel printers where the additional inks are spot colors or varnishes that most colors on the page won’t use.)
 						const coords = Object.keys(space.coords).map((_, i) => env.parsed.args[i] || 0);
 
-						let color = {spaceId: space.id, coords, alpha};
-						return verbose? {color, formatId: "color"} : color;
+						if (meta) {
+							meta.formatId = "color";
+						}
+
+						return {spaceId: space.id, coords, alpha};
 					}
 				}
 			}
@@ -105,12 +107,14 @@ export default function parse (str, {verbose} = {}) {
 						});
 					}
 
-					let color = {
+					if (meta) {
+						Object.assign(meta, {formatId: format.name, types});
+					}
+
+					return {
 						spaceId: space.id,
 						coords, alpha
 					};
-
-					return verbose? {color, formatId: format.name, types} : color;
 				}
 			}
 		}
@@ -134,7 +138,11 @@ export default function parse (str, {verbose} = {}) {
 				if (color) {
 					color.alpha ??= 1;
 
-					return verbose? {color, formatId} : color;
+					if (meta) {
+						meta.formatId = formatId;
+					}
+
+					return color;
 				}
 			}
 		}

--- a/src/parse.js
+++ b/src/parse.js
@@ -71,10 +71,10 @@ export default function parse (str, {verbose} = {}) {
 
 					let coords = env.parsed.args;
 
-					let argTypes;
+					let types;
 
 					if (format.coordGrammar) {
-						argTypes = Object.entries(space.coords).map(([id, coordMeta], i) => {
+						types = Object.entries(space.coords).map(([id, coordMeta], i) => {
 							let coordGrammar = format.coordGrammar[i];
 							let providedType = coords[i]?.type;
 
@@ -89,12 +89,10 @@ export default function parse (str, {verbose} = {}) {
 								throw new TypeError(`${providedType} not allowed for ${coordName} in ${name}()`);
 							}
 
-							let range = type.range || coordMeta.range || coordMeta.refRange;
 							let fromRange = type.range;
 
 							if (providedType === "<percentage>") {
 								fromRange ||= [0, 1];
-								range = [0, 100];
 							}
 
 							let toRange = coordMeta.range || coordMeta.refRange;
@@ -103,7 +101,7 @@ export default function parse (str, {verbose} = {}) {
 								coords[i] = util.mapRange(fromRange, toRange, coords[i]);
 							}
 
-							return {type: type + "", range};
+							return type;
 						});
 					}
 
@@ -112,7 +110,7 @@ export default function parse (str, {verbose} = {}) {
 						coords, alpha
 					};
 
-					return verbose? {color, formatId: format.name, argTypes} : color;
+					return verbose? {color, formatId: format.name, types} : color;
 				}
 			}
 		}

--- a/src/parse.js
+++ b/src/parse.js
@@ -7,7 +7,7 @@ import ColorSpace from "./space.js";
  * @param {string} str
  * @param {object} [options]
  * @param {object} [options.meta] - Object for additional information about the parsing
- * @returns { Color } }
+ * @returns { Color }
  */
 export default function parse (str, {meta} = {}) {
 	let env = {"str": String(str)?.trim()};

--- a/types/src/parse.d.ts
+++ b/types/src/parse.d.ts
@@ -1,4 +1,4 @@
-import { PlainColorObject } from "./color";
+import { ColorConstructor } from "./color";
 
 export interface Options {
 	meta?: object | undefined;
@@ -7,4 +7,4 @@ export interface Options {
 export default function parse(
 	str: string,
 	options?: Options & Record<string, any>
-): PlainColorObject;
+): ColorConstructor;

--- a/types/src/parse.d.ts
+++ b/types/src/parse.d.ts
@@ -1,3 +1,15 @@
-import { ColorConstructor } from "./color";
+import { PlainColorObject } from "./color";
 
-export default function parse(str: string): ColorConstructor;
+export interface Options {
+	verbose?: boolean | undefined;
+}
+
+export interface VerboseParseResult {
+	color: PlainColorObject;
+	formatId?: string | undefined;
+}
+
+export default function parse(
+	str: string,
+	options?: Options & Record<string, any>
+): (PlainColorObject | VerboseParseResult);

--- a/types/src/parse.d.ts
+++ b/types/src/parse.d.ts
@@ -1,15 +1,10 @@
 import { PlainColorObject } from "./color";
 
 export interface Options {
-	verbose?: boolean | undefined;
-}
-
-export interface VerboseParseResult {
-	color: PlainColorObject;
-	formatId?: string | undefined;
+	meta?: object | undefined;
 }
 
 export default function parse(
 	str: string,
 	options?: Options & Record<string, any>
-): (PlainColorObject | VerboseParseResult);
+): PlainColorObject;


### PR DESCRIPTION
The `verbose` option gets `parse()` to return not just the result of the parsing, but also metadata about how the parsing was done.
For now the only metadata is `formatId` (which can be resolved to a format object through `color.space.formats[formatId]`) but more may be added in the future.
This is useful in UIs that handle colors (e.g. I needed it in a color game because I wanted to provide a syntax hint).

A little unsure about whether it's a good idea to have a function that returns a different type based on an option, but having a separate `parseVerbose()` function that `parse()` calls seems overkill.

Requesting review from @jgerigmeyer and @MysteryBlokHed because I don't trust myself with TS definitions yet 😁 
I did change `ColorConstructor` to `ColorObject` there as it seemed more suitable?