### PR TITLE
Use node v14 for CI.

### DIFF
--- a/.github/workflows/test-types.yml
+++ b/.github/workflows/test-types.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "14"
 
       - run: npm install
       - run: npm run dtslint


### PR DESCRIPTION
Many of the tools used in CI no longer support node v12. Now that node v14 is the oldest maintained version, this runs CI against that version. (Other changes are unrelated, but came along with a `npm run build`.)