### PR TITLE
[types] Add missing string option type in toGamut

### DIFF
--- a/src/toGamut.js
+++ b/src/toGamut.js
@@ -12,7 +12,7 @@ import getColor from "./getColor.js";
 /**
  * Force coordinates to be in gamut of a certain color space.
  * Mutates the color it is passed.
- * @param {Object} options
+ * @param {Object|string} options object or spaceId string
  * @param {string} options.method - How to force into gamut.
  *        If "clip", coordinates are just clipped to their reference range.
  *        If in the form [colorSpaceId].[coordName], that coordinate is reduced

--- a/types/src/toGamut.d.ts
+++ b/types/src/toGamut.d.ts
@@ -10,7 +10,7 @@ declare function toGamut(
 	options?: {
 		method?: string | undefined;
 		space?: string | ColorSpace | undefined;
-	}
+	} | string
 ): PlainColorObject;
 
 export default toGamut;

--- a/types/test/toGamut.ts
+++ b/types/test/toGamut.ts
@@ -10,3 +10,4 @@ toGamut("red"); // $ExpectType PlainColorObject
 toGamut(new Color("red")); // $ExpectType PlainColorObject
 toGamut(new Color("red"), { method: "clip", space: "srgb" }); // $ExpectType PlainColorObject
 toGamut(new Color("red"), { method: "clip", space: sRGB }); // $ExpectType PlainColorObject
+toGamut(new Color("red"), "srgb"); // $ExpectType PlainColorObject


### PR DESCRIPTION
Only types are added to match functionality
https://github.com/LeaVerou/color.js/blob/f22556161af0caf03bff447ff86b918d125ccbe4/src/toGamut.js#L23-L28