### PR TITLE
[navigation] Fix menu z-index on the play page

### DIFF
--- a/assets/css/style.postcss
+++ b/assets/css/style.postcss
@@ -177,7 +177,7 @@ body > footer {
 
 			& > ul {
 				position: absolute;
-				z-index: 1;
+				z-index: 3;
 				padding: 0;
 				margin: 0;
 				list-style: none;


### PR DESCRIPTION
Before it was quite impossible to reach items below the grey bar.

|before|after|
|-|-|
| ![Screenshot with menu behind login and carbon ad](https://github.com/LeaVerou/color.js/assets/3001985/86c574cc-90bc-4073-b90d-2fa677ccc0c7) | ![Screenshot with menu on top of everything](https://github.com/LeaVerou/color.js/assets/3001985/75b7ed43-07c6-4a8d-85c1-5fb77268e17c) |
