### PR TITLE
[types] Fix signature of `steps` function

### DIFF
--- a/types/src/interpolation.d.ts
+++ b/types/src/interpolation.d.ts
@@ -48,7 +48,7 @@ export interface StepsOptions extends RangeOptions {
 	maxSteps?: number | undefined;
 }
 
-export function steps(color1: ColorTypes, color2: ColorTypes, options?: StepsOptions): PlainColorObject[];
-export function steps(range: Range, options?: StepsOptions): PlainColorObject[];
+export function steps(range: Range, options?: StepsOptions): Color[];
+export function steps(color1: ColorTypes, color2: ColorTypes, options?: StepsOptions): Color[];
 
 export function register(color: typeof Color): void;

--- a/types/test/interpolation.ts
+++ b/types/test/interpolation.ts
@@ -47,16 +47,16 @@ mix("red", "blue", {
 	premultiplied: true,
 });
 
-steps("red", "blue"); // $ExpectType PlainColorObject[]
-// $ExpectType PlainColorObject[]
+steps("red", "blue"); // $ExpectType Color[]
+// $ExpectType Color[]
 steps("red", "blue", {
 	maxDeltaE: 1,
 	deltaEMethod: "2000",
 	steps: 10,
 	maxSteps: 100,
 });
-steps(r); // $ExpectType PlainColorObject[]
-// $ExpectType PlainColorObject[]
+steps(r); // $ExpectType Color[]
+// $ExpectType Color[]
 steps(r, {
 	maxDeltaE: 1,
 	deltaEMethod: "2000",
@@ -65,7 +65,12 @@ steps(r, {
 });
 
 // @ts-expect-error
-steps(r, "blue"); // $ExpectType PlainColorObject[]
+steps(r, "blue");
+
+// Test steps on Color class
+Color.steps(Color.range("red", "blue")); // $ExpectType Color[]
+Color.steps("red", "blue"); // $ExpectType Color[]
+new Color("red").steps("blue"); // $ExpectType Color[]
 
 // @ts-expect-error
 register();


### PR DESCRIPTION
Fixes #322

This PR does two things:
- Changes the order of the `steps` overload so that the correct signature is used [here](https://github.com/LeaVerou/color.js/blob/2bd19b0a913da3f3310b9d8c1daa859ceb123c37/types/src/index.d.ts#L72)
- Changes the return type of `steps` back to the actual `Color` class