### PR TITLE
[types] Re-export some types at the top level

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,26 @@
 // Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
 // Minimum TypeScript Version: 4.1
 export { default } from "./dist/color";
+export type * from "./src/color";
+
+export type { CAT } from "./src/CATs";
+
+export type { Display } from "./src/display";
+
+export type {
+	Range,
+	RangeOptions,
+	MixOptions,
+	StepsOptions,
+} from "./src/interpolation";
+
+export type { RGBOptions } from "./src/rgbspace";
+
+export type { Options as SerializeOptions } from "./src/serialize";
+
+export type {
+	Format as SpaceFormat,
+	CoordMeta,
+	Ref,
+	Options as SpacecOptions,
+} from "./src/space";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,6 +24,8 @@ export type {
 	StepsOptions,
 } from "./src/interpolation";
 
+export type { Options as ParseOptions } from "./src/parse";
+
 export type { RGBOptions } from "./src/rgbspace";
 
 export type { Options as SerializeOptions } from "./src/serialize";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,5 +37,5 @@ export type {
 	Format as SpaceFormat,
 	CoordMeta,
 	Ref,
-	Options as SpacecOptions,
+	Options as SpaceOptions,
 } from "./src/space";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,6 +9,7 @@ export type {
 	DefineFunctionCode,
 	DefineFunctionOptions,
 	DefineFunctionHybrid,
+	PlainColorObject,
 	SpaceAccessor,
 	ToColorPrototype,
 } from "./src/color";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,6 +13,8 @@ export type {
 	ToColorPrototype,
 } from "./src/color";
 
+export type { White } from "./src/adapt";
+
 export type { CAT } from "./src/CATs";
 
 export type { Display } from "./src/display";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,17 @@
 // Definitions by: Adam Thompson-Sharpe <https://github.com/MysteryBlokHed>
 // Minimum TypeScript Version: 4.1
 export { default } from "./dist/color";
-export type * from "./src/color";
+export type {
+	ColorConstructor,
+	ColorObject,
+	ColorTypes,
+	Coords,
+	DefineFunctionCode,
+	DefineFunctionOptions,
+	DefineFunctionHybrid,
+	SpaceAccessor,
+	ToColorPrototype,
+} from "./src/color";
 
 export type { CAT } from "./src/CATs";
 

--- a/types/test/type-accessibility.ts
+++ b/types/test/type-accessibility.ts
@@ -9,6 +9,7 @@ import {
 	DefineFunctionCode,
 	DefineFunctionOptions,
 	DefineFunctionHybrid,
+	PlainColorObject,
 	SpaceAccessor,
 	ToColorPrototype,
 	// Re-exported from src/CATs.d.ts

--- a/types/test/type-accessibility.ts
+++ b/types/test/type-accessibility.ts
@@ -33,5 +33,5 @@ import {
 	SpaceFormat,
 	CoordMeta,
 	Ref,
-	SpacecOptions,
+	SpaceOptions,
 } from "colorjs.io";

--- a/types/test/type-accessibility.ts
+++ b/types/test/type-accessibility.ts
@@ -1,0 +1,32 @@
+// Testing whether types can be accessed from the main import
+
+import {
+	// Re-exported from src/color.d.ts
+	ColorConstructor,
+	ColorObject,
+	ColorTypes,
+	Coords,
+	DefineFunctionCode,
+	DefineFunctionOptions,
+	DefineFunctionHybrid,
+	SpaceAccessor,
+	ToColorPrototype,
+	// Re-exported from src/CATs.d.ts
+	CAT,
+	// Re-exported from src/display.d.ts
+	Display,
+	// Re-exported from src/interpolation.d.ts
+	Range,
+	RangeOptions,
+	MixOptions,
+	StepsOptions,
+	// Re-exported from src/rgbspace.d.ts
+	RGBOptions,
+	// Re-exported from src/serialize.d.ts
+	SerializeOptions,
+	// Re-exported from src/space.d.ts
+	SpaceFormat,
+	CoordMeta,
+	Ref,
+	SpacecOptions,
+} from "colorjs.io";

--- a/types/test/type-accessibility.ts
+++ b/types/test/type-accessibility.ts
@@ -23,6 +23,8 @@ import {
 	RangeOptions,
 	MixOptions,
 	StepsOptions,
+	// Re-exported from src/parse.d.ts
+	ParseOptions,
 	// Re-exported from src/rgbspace.d.ts
 	RGBOptions,
 	// Re-exported from src/serialize.d.ts

--- a/types/test/type-accessibility.ts
+++ b/types/test/type-accessibility.ts
@@ -12,6 +12,8 @@ import {
 	PlainColorObject,
 	SpaceAccessor,
 	ToColorPrototype,
+	// Re-exported from src/adapt.d.ts
+	White,
 	// Re-exported from src/CATs.d.ts
 	CAT,
 	// Re-exported from src/display.d.ts

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -10,6 +10,6 @@
 		"noEmit": true,
 		"forceConsistentCasingInFileNames": true,
 		"baseUrl": ".",
-		"paths": { "colorjs.io/*": ["./*"] }
+		"paths": { "colorjs.io": ["."], "colorjs.io/*": ["./*"] }
 	}
 }


### PR DESCRIPTION
Closes #326

Re-exports some potentially desirable types at the top level instead of requiring them to be manually imported from their individual files.

I basically just went through the files in `types/src` and added `export`s in the main `index.d.ts` file for types and interfaces that might be wanted.

LMK if there are any other types that I missed 😊