### PR TITLE
[apps/picker] input number step setting

### DIFF
--- a/apps/picker/index.html
+++ b/apps/picker/index.html
@@ -23,7 +23,7 @@
 		<label v-for="(meta, i) in coord_meta" class="color-slider-label">
 			{{ meta.name }} ({{ meta.min }}-{{ meta.max }})
 			<input class="color-slider" type="range" v-model.number="coords[i]" :style="`--stops: ${ slider_steps[i] }`" :min="meta.min" :max="meta.max" :step="meta.step" />
-			<input type="number" v-model.number="coords[i]" class="autosize" :style="`--percentage: ${coords[i] / (meta.max - meta.min) }`" :min="meta.min" :max="meta.max" />
+			<input type="number" v-model.number="coords[i]" class="autosize" :style="`--percentage: ${coords[i] / (meta.max - meta.min) }`" :min="meta.min" :max="meta.max :step="meta.step" />
 		</label>
 
 		<label class="color-slider-label">Alpha (0-100)


### PR DESCRIPTION
The `<input type="number">` that floats above the color sliders doesn't have the step attribute set, so it's always set to 1.  This fix *should* set it to the correct resolution.  The *italics* are because I have not figured out how to view the page with these changes.  Sorry about that.  I'm new to npm and I ran `npm run watch:html` but then I didn't know what port to use or how to view the changes in a browser.  Github Pages won't build a site either.  I'm also unfamiliar with the ":attribute" syntax, as in `:style="..."`.  The `<input type="range">` right above the number spinner sets this same property this same way, so this seems to me like a viable fix.

If you want to reproduce this as a problem, select any RGB color space and try to change a value using one of these inputs.  It displays 0.XXX but the step is set to 1, so if you click on either spin button it sets to value to 0 or 1 immediately.

Also note: On both Chrome and Firefox in Windows, the spinner buttons crowd the numbers.  Part of the problem is that the numbers are not truncated/rounded and can have lots of decimals, but the control should be a bit wider regardless.  I didn't see any styling for it.  Maybe the width is set via "https://stretchy.verou.me/dist/stretchy.iife.min.js"?

If someone points me in the right direction I can amend this PR to include a rounding or truncating of these numbers to the precision set by the precision input or to some fixed value.  If it's set to the user setting, then the width will have to adjust accordingly.