### PR TITLE
Add CJS file to `/fn` entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,8 @@
 	"version": "0.4.5",
 	"description": "Let’s get serious about color",
 	"files": [
-		"dist/color.cjs",
-		"dist/color.cjs.map",
-		"dist/color.js",
-		"dist/color.js.map",
-		"dist/color.legacy.cjs",
-		"dist/color.legacy.cjs.map",
-		"dist/color.legacy.js",
-		"dist/color.legacy.js.map",
+		"dist/color-fn.*",
+		"dist/color.*",
 		"src/",
 		"types/dist/",
 		"types/src/",
@@ -24,7 +18,8 @@
 		},
 		"./fn": {
 			"types": "./types/src/index-fn.d.ts",
-			"import": "./src/index-fn.js"
+			"import": "./src/index-fn.js",
+			"require": "./dist/color-fn.cjs"
 		},
 		"./dist/*": "./dist/*"
 	},

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,22 +20,44 @@ let bundles = [
 	},
 ];
 
+let fnBundles = [
+	{
+		"file": "dist/color-fn.cjs",
+		"format": "cjs",
+		"sourcemap": true,
+		"exports": "named",
+	},
+];
+
 // Add minified versions of every bundle
-bundles = bundles.flatMap(bundle => {
-	let minBundle = Object.assign({}, bundle);
-	minBundle.file = minBundle.file.replace(/\.\w+$/, ".min$&");
-	minBundle.plugins ||= [];
-	minBundle.plugins.push(terser());
+let addMinBundle = (bundles) => {
+	return bundles.flatMap(bundle => {
+		let minBundle = Object.assign({}, bundle);
+		minBundle.file = minBundle.file.replace(/\.\w+$/, ".min$&");
+		minBundle.plugins ||= [];
+		minBundle.plugins.push(terser());
 
-	return [bundle, minBundle];
-});
+		return [bundle, minBundle];
+	})
+}
 
-export default {
-	input: "src/index.js",
-	output: bundles,
-	onwarn (warning, rollupWarn) {
-		if (warning.code !== "CIRCULAR_DEPENDENCY") {
-			rollupWarn(warning);
+export default [
+	{
+		input: "src/index.js",
+		output: addMinBundle(bundles),
+		onwarn (warning, rollupWarn) {
+			if (warning.code !== "CIRCULAR_DEPENDENCY") {
+				rollupWarn(warning);
+			}
 		}
-	}
-};
+	},
+	{
+		input: "src/index-fn.js",
+		output: addMinBundle(fnBundles),
+		onwarn (warning, rollupWarn) {
+			if (warning.code !== "CIRCULAR_DEPENDENCY") {
+				rollupWarn(warning);
+			}
+		}
+	},
+]

--- a/rollup.legacy.config.js
+++ b/rollup.legacy.config.js
@@ -10,10 +10,12 @@ const legacyPlugins = [
 	babel({ babelHelpers: "bundled", exclude: "node_modules/**" }),
 ];
 
-export default Object.assign(defaultConfig, {
-	output: defaultConfig.output.map(bundle => ({
-		...bundle,
-		file: bundle.file.replace(/\.(?:min\.)?\w+$/, ".legacy$&"),
-	})),
-	plugins: [...(defaultConfig.plugins || []), ...legacyPlugins]
-});
+export default defaultConfig.map(config =>
+	 Object.assign(config, {
+		output: config.output.map(bundle => ({
+			...bundle,
+			file: bundle.file.replace(/\.(?:min\.)?\w+$/, ".legacy$&"),
+		})),
+		plugins: [...(config.plugins || []), ...legacyPlugins]
+	})
+)


### PR DESCRIPTION
- Add CJS file to `/fn` entry, which is especially useful in universal webpack apps, make it consistent with the main entry
- Change files pattern in package.json, some dist files are missing (min/global), see https://unpkg.com/browse/colorjs.io@0.4.5/dist/