### PR TITLE
[apps/gradient] pin mavo to hotfix app

### DIFF
--- a/apps/gradients/index.html
+++ b/apps/gradients/index.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="https://get.mavo.io/mavo.css">
 <link rel="stylesheet" href="style.css">
 
-<script src="https://get.mavo.io/stable/mavo.js"></script>
+<script src="https://get.mavo.io/v0.2.4/mavo.js"></script>
 <script src="../../color.js" type="module"></script>
 
 </head>


### PR DESCRIPTION
fixes #353

better fix is to migrate to the new mavo.js version, but this should make sure the app is working again